### PR TITLE
Support matching Windows-rooted globs

### DIFF
--- a/lib/glob_ex.ex
+++ b/lib/glob_ex.ex
@@ -196,6 +196,17 @@ defmodule GlobEx do
     end
   end
 
+  defp match?([{:root, volume} | glob], match_dot, [component | path]) do
+    volume_component = Enum.drop(volume, -1)
+
+    if String.downcase(List.to_string(volume_component)) ==
+         String.downcase(List.to_string(component)) do
+      match?(glob, match_dot, path)
+    else
+      false
+    end
+  end
+
   defp match?([:root, {:exact, exact} | glob], match_dot, [[], comp | path]) do
     if exact == comp do
       with {glob, path} <- exact(glob, path) do

--- a/test/glob_ex_test.exs
+++ b/test/glob_ex_test.exs
@@ -643,6 +643,8 @@ defmodule GlobExTest do
     prove GlobEx.match?(~g|foo|, "FOO") == false
     prove GlobEx.match?(~g|héllò|, "héllò") == true
     prove GlobEx.match?(~g|foo/bar/baz|, "foo/bar/baz") == true
+    prove GlobEx.match?(~g|c:/Users/**|, "c:/Users/example/file.txt") == true
+    prove GlobEx.match?(~g|c:/Users/**|, "C:/Users/example/file.txt") == true
     prove GlobEx.match?(~g|.foo/.bar/.baz|, ".foo/.bar/.baz") == true
     prove GlobEx.match?(~g|.foo/.bar/.baz|d, ".foo/.bar/.baz") == true
     prove GlobEx.match?(~g|.foo/.bar/*|, ".foo/.bar/.baz") == false


### PR DESCRIPTION
## Summary

- match drive-root glob components against Windows path volumes
- compare drive letters case-insensitively
- cover same-case and mixed-case rooted paths

Windows-rooted patterns compile their volume as a `{:root, volume}` component, while candidate paths present the drive as their first path component. Without a matching clause, patterns such as `c:/Users/**` never match rooted Windows paths.

## Testing

- `mix test` — 251 passed
- validated as part of Volt's local Windows test suite
